### PR TITLE
compatibility with `cmor==3.14.2` and `cmip7-cmor-tables` tag DR-1.2.2.3-v1.0.6

### DIFF
--- a/.cspell/ok-unknown-words.txt
+++ b/.cspell/ok-unknown-words.txt
@@ -63,6 +63,7 @@ autoattribute
 autoclass
 autodoc
 autofunction
+autouse
 automethod
 automodule
 basetemp

--- a/.cspell/ok-unknown-words.txt
+++ b/.cspell/ok-unknown-words.txt
@@ -65,6 +65,7 @@ autodoc
 autofunction
 automethod
 automodule
+basetemp
 bnds
 booleaness
 capfd
@@ -100,6 +101,7 @@ ierr
 ilaflott
 indir
 infolog
+inlinevar
 intercomparison
 intercomparisons
 interp
@@ -129,6 +131,7 @@ msvs
 mymodule
 mypackage
 mypy
+mylog
 ncattrs
 ncgen
 ncrc

--- a/.github/workflows/build_conda.yml
+++ b/.github/workflows/build_conda.yml
@@ -26,7 +26,9 @@ jobs:
       - name: Setup Conda
         uses: conda-incubator/setup-miniconda@v3
         with:
-          auto-activate-base: true
+          auto-activate: true
+          activate-environment: base
+          conda-remove-defaults: true
           miniforge-version: latest
           channels: conda-forge,noaa-gfdl
 

--- a/.github/workflows/create_test_conda_env.yml
+++ b/.github/workflows/create_test_conda_env.yml
@@ -17,6 +17,8 @@ permissions:
 jobs:
   conda-test:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "3.13", "3.14"]

--- a/.github/workflows/publish_conda.yml
+++ b/.github/workflows/publish_conda.yml
@@ -24,7 +24,10 @@ jobs:
       - name: Setup Conda
         uses: conda-incubator/setup-miniconda@v3
         with:
-          auto-activate-base: true
+          auto-activate: true
+          activate-environment: base
+          conda-remove-defaults: true
+          miniforge-version: latest
           channels: conda-forge,noaa-gfdl,ilaflott
 
       - name: Configure Conda

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -29,8 +29,9 @@ jobs:
         with:
           activate-environment: fremorizer
           environment-file: environment.yaml
-          auto-activate-base: false
+          auto-activate: false
           miniforge-version: latest
+          conda-remove-defaults: true
 
       - name: Configure Conda
         run: |

--- a/.github/workflows/wcrp_compliance_check.yml
+++ b/.github/workflows/wcrp_compliance_check.yml
@@ -29,7 +29,8 @@ jobs:
         with:
           activate-environment: fremorizer-wcrp
           environment-file: environment.yaml
-          auto-activate-base: false
+          conda-remove-defaults: true
+          auto-activate: false
           miniforge-version: latest
           channels: conda-forge,noaa-gfdl
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 * Developers are free to use this repository's `README.md` to familiarize with the CLI and save time from having to install any dependencies, but development within a Conda environment is heavily recommended regardless
 * Gain access to the repository with `git clone --recursive git@github.com:ilaflott/fremorizer.git` or your fork's link (recommended) and an SSH RSA key
-    - Once inside the repository, developers can test local changes by running a `pip install .` inside of the root directory after activating a virtual environment, installing the fremorizer package locally with the newest local changes on top of the installed Conda fremorizer dependencies. the `-e` flag can be used for an editable installtion
+    - Once inside the repository, developers can test local changes by running a `pip install .` inside of the root directory after activating a virtual environment, installing the fremorizer package locally with the newest local changes on top of the installed Conda fremorizer dependencies. the `-e` flag can be used for an editable installation
     - Test as a normal user would use the CLI
 * Create a GitHub issue to reflect your contribution's background and reference it with Git commits
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ cd fremorizer
 
 # create an environment and install the local checkout
 conda env create -f environment.yaml
-conda actiavte fremorizer
+conda activate fremorizer
 pip install -e . 
 
 # Run tests
@@ -102,7 +102,7 @@ pylint --rcfile pylintrc fremorizer/
 
 
 ### as a command line interface (CLI)
-The CLI entry point is `fremor`, currently a suite of (currently) six routines for facillitating data preparation for
+The CLI entry point is `fremor`, currently a suite of (currently) six routines for facilitating data preparation for
 CMIP7. 
 ```bash
 # The full list of subcommands

--- a/fremorizer/cmor_constants.py
+++ b/fremorizer/cmor_constants.py
@@ -50,7 +50,7 @@ DEPTH_COORDS = ['z_l']
 # ---------------------------------------------------------------------------
 CMOR_NC_FILE_ACTION = cmor.CMOR_REPLACE
 CMOR_VERBOSITY      = cmor.CMOR_NORMAL#cmor.CMOR_QUIET#
-CMOR_EXIT_CTL       = cmor.cmor.CMOR_NORMAL#CMOR_EXIT_ON_WARNING#
+CMOR_EXIT_CTL       = cmor.CMOR_NORMAL#CMOR_EXIT_ON_WARNING#
 CMOR_MK_SUBDIRS     = 1
 CMOR_LOG             = None
 

--- a/fremorizer/cmor_constants.py
+++ b/fremorizer/cmor_constants.py
@@ -49,8 +49,8 @@ DEPTH_COORDS = ['z_l']
 # CMOR module defaults (passed to cmor.setup in cmor_mixer)
 # ---------------------------------------------------------------------------
 CMOR_NC_FILE_ACTION = cmor.CMOR_REPLACE
-CMOR_VERBOSITY      = cmor.CMOR_NORMAL
-CMOR_EXIT_CTL       = cmor.CMOR_NORMAL
+CMOR_VERBOSITY      = cmor.CMOR_NORMAL#cmor.CMOR_QUIET#
+CMOR_EXIT_CTL       = cmor.cmor.CMOR_NORMAL#CMOR_EXIT_ON_WARNING#
 CMOR_MK_SUBDIRS     = 1
 CMOR_LOG             = None
 

--- a/fremorizer/cmor_mixer.py
+++ b/fremorizer/cmor_mixer.py
@@ -506,7 +506,7 @@ def rewrite_netcdf_file_var( mip_var_cfgs: dict = None,
                                    coord_vals=lev[:], units=lev_units)
             else:
                 landuse_str_list = ['primary_and_secondary_land', 'pastures', 'crops', 'urban']
-                cmor_vert_dim_name = 'landUse'
+                cmor_vert_dim_name = 'landUse' if exp_cfg_mip_era == 'CMIP6' else 'landuse'
                 cmor_z = cmor.axis(cmor_vert_dim_name,
                                    coord_vals=np.array(
                                        landuse_str_list,

--- a/fremorizer/tests/conftest.py
+++ b/fremorizer/tests/conftest.py
@@ -155,7 +155,7 @@ def _write_exp_configs():
 
     The JSON data lives in this module (_CMIP6_EXP_CONFIG_DATA /
     _CMIP7_EXP_CONFIG_DATA) so the on-disk files are no longer tracked by git.
-    This session-scoped autouse fixture materialises fresh copies before any
+    This session-scoped autouse fixture materializes fresh copies before any
     test that needs them runs, and cleans them up afterwards.
     """
     EXP_CONFIG.write_text(json.dumps(_CMIP6_EXP_CONFIG_DATA, indent=4))

--- a/fremorizer/tests/test_cmor_run_subtool.py
+++ b/fremorizer/tests/test_cmor_run_subtool.py
@@ -374,7 +374,7 @@ def test_exp_config_cleanup():
     Restores the CMIP6 experiment config to its pristine state after tests
     that mutate it in-place (e.g. grid / calendar updates).
 
-    The config is no longer tracked by git — it is materialised by a
+    The config is no longer tracked by git — it is materialized by a
     session-scoped conftest fixture — so we rewrite it from the canonical
     fixture data instead of running ``git restore``.
     """

--- a/fremorizer/tests/test_cmor_run_subtool_cmip7_further_examples.py
+++ b/fremorizer/tests/test_cmor_run_subtool_cmip7_further_examples.py
@@ -152,12 +152,12 @@ def test_case_cmip7(  # pylint: disable=too-many-arguments,too-many-positional-a
             '(CMIP7 uses ch4 variants instead); '
             'needs new mock data or a different variable mapping'
         )
-    if opt_var_name == 'gppLut':
-        pytest.skip(
-            'gppLut_tavg-u-hxy-multi cmor.axis fails: '
-            'CMIP7 landuse coordinate definition is incompatible '
-            'with the mock archive landuse axis values'
-        )
+    #if opt_var_name == 'gppLut':
+    #    pytest.skip(
+    #        'gppLut_tavg-u-hxy-multi cmor.axis fails: '
+    #        'CMIP7 landuse coordinate definition is incompatible '
+    #        'with the mock archive landuse axis values'
+    #    )
 
     # native-grid ocean tests: prevent gold statics lookup from finding /archive files
     if grid_label == 'gn':

--- a/fremorizer/tests/test_cmor_run_subtool_cmip7_further_examples.py
+++ b/fremorizer/tests/test_cmor_run_subtool_cmip7_further_examples.py
@@ -31,7 +31,7 @@ CMORBITE_VARLIST = f'{ROOTDIR}/CMORbite_var_list.json'
 # cmip7 table repo
 CMIP7_TABLE_REPO_PATH = f'{ROOTDIR}/cmip7-cmor-tables'
 
-# experiment config (materialised by conftest._write_exp_configs)
+# experiment config (materialized by conftest._write_exp_configs)
 EXP_CONFIG_CMIP7 = f'{ROOTDIR}/CMOR_CMIP7_input_example.json'
 
 # determined by cmor_run_subtool

--- a/fremorizer/tests/test_cmor_run_subtool_further_examples.py
+++ b/fremorizer/tests/test_cmor_run_subtool_further_examples.py
@@ -30,7 +30,7 @@ CMORBITE_VARLIST = f'{ROOTDIR}/CMORbite_var_list.json'
 # cmip6 table repo
 CMIP6_TABLE_REPO_PATH = f'{ROOTDIR}/cmip6-cmor-tables'
 
-# experiment config (materialised by conftest._write_exp_configs)
+# experiment config (materialized by conftest._write_exp_configs)
 EXP_CONFIG_CMIP6 = f'{ROOTDIR}/CMOR_input_example.json'
 
 # determined by cmor_run_subtool


### PR DESCRIPTION
## Describe your changes
- update list of ok unknown words and spelling errors
- bump `cmip7-cmor-tables` to DR-1.2.2.3-v1.0.6 --> allows us to enable `gppLut` CMIP7 unit-test
- address some workflow warnings about `conda`/`miniforge` configuration with `setup-conda` actions
