### PR TITLE
Improve vertical dim search

### DIFF
--- a/fremor/cmor_helpers.py
+++ b/fremor/cmor_helpers.py
@@ -157,7 +157,7 @@ def from_dis_gimme_dis( from_dis: Dataset,
     try:
         return from_dis[gimme_dis][:].copy()
     except Exception:
-        fre_logger.warning('I am sorry, I could not not give you this: %s\n returning None!\n', gimme_dis)
+        fre_logger.exception('I am sorry, I could not not give you this: %s\n returning None!\n', gimme_dis)
         return None
 
 
@@ -420,6 +420,8 @@ def get_vertical_dimension( ds: Dataset,
             if dim.lower() == 'landuse':
                 vert_dim = dim
                 break
+            if 'axis' not in ds[dim].ncattrs():
+                continue
             if not (ds[dim].axis and ds[dim].axis == 'Z'):
                 continue
             vert_dim = dim

--- a/fremor/cmor_mixer.py
+++ b/fremor/cmor_mixer.py
@@ -744,8 +744,7 @@ def cmorize_all_variables_in_dir(vars_to_run: Dict[str, Any],
             return_status = 0
         except Exception as exc: #uncovered
             return_status = 1
-            fre_logger.warning('!!!EXCEPTION CAUGHT!!!   !!!READ THE NEXT LINE!!!')
-            fre_logger.warning('exc=%s', exc)
+            fre_logger.exception('!!!EXCEPTION CAUGHT!!!')
             fre_logger.warning('this message came from within cmorize_target_var_files')
             fre_logger.warning('COULD NOT PROCESS: %s/%s...moving on', local_var, target_var)
             expected_files = [


### PR DESCRIPTION
uses `logging.exception` instead in `cmor_mixer` `try`/`except` behavior
skip the `dimension` variable if it does not have an `axis` attribute to check when searching for a vertical dimension in `cmor_helpers`
